### PR TITLE
openpaas-gatling#19: Provided a way to load the main.js file

### DIFF
--- a/src/main/scala/com/linagora/openpaas/gatling/core/SessionKeys.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/SessionKeys.scala
@@ -1,0 +1,6 @@
+package com.linagora.openpaas.gatling.core
+
+object SessionKeys {
+  val IndexHtmlContent = "indexHtmlContent"
+  val MainJsUrl = "mainJsUrl"
+}

--- a/src/main/scala/com/linagora/openpaas/gatling/core/StaticAssetsSteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/StaticAssetsSteps.scala
@@ -1,0 +1,40 @@
+package com.linagora.openpaas.gatling.core
+
+import com.linagora.openpaas.gatling.core.SessionKeys._
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import io.gatling.http.Predef._
+import io.gatling.http.request.builder.HttpRequestBuilder
+
+import scala.util.matching.Regex
+
+object StaticAssetsSteps {
+  def loadIndexHtml(spaName: String): HttpRequestBuilder = {
+    http("loadIndexHtml")
+      .get(s"/${spaName.toLowerCase()}")
+      .check(status is 200)
+      .check(bodyString.saveAs(IndexHtmlContent))
+  }
+
+  def loadMainJs(): HttpRequestBuilder = {
+    http("loadMainJs")
+      .get(s"$${$MainJsUrl}")
+      .check(status is 200)
+  }
+
+  def loadIndexHtmlAndMainJs(spaName: String): ChainBuilder = {
+    group("loadIndexHtmlAndMainJs") {
+      exec(loadIndexHtml(spaName))
+        .exec(session => extractMainJsUrl(spaName)(session))
+        .exec(loadMainJs())
+    }
+  }
+
+  def extractMainJsUrl(spaName: String)(session: Session): Session = {
+    val indexHtmlContent: String = session(IndexHtmlContent).as[String]
+    val matchMainJsUrlRegex: Regex = raw""""\/${spaName.toLowerCase()}\/main(.*?)"""".r
+    val mainJsUrl: String = matchMainJsUrlRegex.findFirstIn(indexHtmlContent).mkString.drop(1).dropRight(1)
+
+    session.set(MainJsUrl, mainJsUrl)
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/openpaas-gatling/issues/19.

Example usage:

```scala
  def openCalendarSPA(): ChainBuilder = {
    group("openCalendarSPA") {
      exec(LoginSteps.loadLoginTemplates)
        .exec(LoginSteps.login())
        .exec(StaticAssetsSteps.loadIndexHtmlAndMainJs(CalendarSpaName)) // CalendarSpaName = "calendar"
       //...
    }
  }
```