### PR TITLE
openpaas-gatling#15: Fixed headers for requests in CalendarSteps and EventSteps

### DIFF
--- a/src/main/scala/com/linagora/openpaas/gatling/calendar/CalendarSteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/calendar/CalendarSteps.scala
@@ -22,6 +22,7 @@ object CalendarSteps {
         .exec(LoginSteps.login())
         .exec(StaticAssetsSteps.loadIndexHtmlAndMainJs(CalendarSpaPath))
         .exec(StaticAssetsSteps.loadStaticAssets(CalendarStaticAssets.OpeningCalendarAssets))
+        .exec(session => StaticAssetsSteps.clearIndexHtmlContentInSession(session))
         .exec(TokenSteps.retrieveAuthenticationToken)
         .exec(WebSocketSteps.getSocketId)
         .exec(WebSocketSteps.registerSocketNamespaces)
@@ -39,6 +40,8 @@ object CalendarSteps {
   def createCalendar(): HttpRequestBuilder = {
     http("createCalendar")
       .post(s"$SabreBaseUrl/calendars/$${$UserId}")
+      .header("Accept", "application/json, text/plain, */*")
+      .header("Content-Type", "application/calendar+json")
       .header(ESNToken, s"$${$Token}")
       .body(StringBody(session => {
         val calId: String = randomUuidString
@@ -65,6 +68,8 @@ object CalendarSteps {
   def updateCalendar(): HttpRequestBuilder = {
     http("updateCalendar")
       .httpRequest("PROPPATCH", s"$SabreBaseUrl$${$CalendarLink}")
+      .header("Accept", "application/json, text/plain, */*")
+      .header("Content-Type", "application/calendar+json")
       .header(ESNToken, s"$${$Token}")
       .body(StringBody(s"$${$NewCalendarContent}"))
       .check(status is 204)
@@ -91,12 +96,14 @@ object CalendarSteps {
   def listCalendarsForUser(): HttpRequestBuilder =
     http("listCalendars")
       .get(s"$SabreBaseUrl/calendars/$${$UserId}.json")
+      .header("Accept", "application/json, text/plain, */*")
       .header(ESNToken, s"$${$Token}")
       .check(status in(200, 304))
 
   def listUsableCalendarsForUser(): HttpRequestBuilder =
     http("listUsableCalendars")
       .get(s"$SabreBaseUrl/calendars/$${$UserId}.json?personal=true&sharedDelegationStatus=accepted&sharedPublicSubscription=true&withRights=true")
+      .header("Accept", "application/json, text/plain, */*")
       .header(ESNToken, s"$${$Token}")
       .check(status in(200, 304))
       .check(jsonPath("$._embedded['dav:calendar'][*]._links.self.href").saveAs(CalendarLinks))
@@ -110,7 +117,9 @@ object CalendarSteps {
   def getCalendarByCalendarIdInSession(): HttpRequestBuilder =
     http("getDefaultCalendar")
       .get(s"$SabreBaseUrl/calendars/$${$UserId}/$${$CalendarId}.json?withRights=true")
+      .header("Accept", "application/json, text/plain, */*")
       .header(ESNToken, s"$${$Token}")
+      .header("Accept", "application/json")
       .check(jsonPath("$").saveAs(CalendarContent))
       .check(jsonPath("$._links.self.href").saveAs(CalendarLink))
       .check(status is 200)
@@ -118,6 +127,7 @@ object CalendarSteps {
   def getDefaultCalendar(): HttpRequestBuilder =
     http("getDefaultCalendar")
       .get(s"$SabreBaseUrl/calendars/$${$UserId}/$${$UserId}.json?withRights=true")
+      .header("Accept", "application/json, text/plain, */*")
       .header(ESNToken, s"$${$Token}")
       .check(jsonPath("$").saveAs(CalendarContent))
       .check(jsonPath("$._links.self.href").saveAs(CalendarLink))

--- a/src/main/scala/com/linagora/openpaas/gatling/calendar/EventSteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/calendar/EventSteps.scala
@@ -22,6 +22,8 @@ object EventSteps {
   def createEventInDefaultCalendar(): HttpRequestBuilder = {
     http("createEvent")
       .put(s"$SabreBaseUrl/calendars/$${$UserId}/$${$UserId}/$${$EventUuid}.ics")
+      .header("Accept", "application/json, text/plain, */*")
+      .header("Content-Type", "application/calendar+json")
       .header(ESNToken, s"$${$Token}")
       .body(StringBody(s"""
         [
@@ -35,7 +37,7 @@ object EventSteps {
                 ["dtstart",{"tzid": "Europe/Berlin"},"date-time","2019-10-22T14:00:00"],
                 ["dtend",{"tzid": "Europe/Berlin"},"date-time","2019-10-22T15:00:00"],
                 ["summary",{},"text","event-$${$EventUuid}"],
-                ["organizer",{"cn": "$UsernameSessionParam"},"cal-address","mailto:$UsernameSessionParam}"],
+                ["organizer",{"cn": "$${$UsernameSessionParam}"},"cal-address","mailto:$${$UsernameSessionParam}"],
                 ["attendee",{"partstat": "ACCEPTED","rsvp": "FALSE","role": "CHAIR","cutype": "INDIVIDUAL"},"cal-address","mailto:$${$UsernameSessionParam}"]
               ],
               []
@@ -51,6 +53,8 @@ object EventSteps {
 
     http("createEventWithAttendees")
       .put(s"$SabreBaseUrl/calendars/$${$UserId}/$${$UserId}/$${$EventUuid}.ics")
+      .header("Accept", "application/json, text/plain, */*")
+      .header("Content-Type", "application/calendar+json")
       .header(ESNToken, s"$${$Token}")
       .body(StringBody(s"""
         [
@@ -83,6 +87,8 @@ object EventSteps {
 
     http("listEvents")
       .httpRequest("REPORT", s"$SabreBaseUrl$${$CalendarLink}")
+      .header("Accept", "application/json, text/plain, */*")
+      .header("Content-Type", "application/calendar+json")
       .header(ESNToken, s"$${$Token}")
       .body(StringBody (s"""{"match":{"start":"${dateTimeFormatter.format(start)}T000000","end":"${dateTimeFormatter.format(end)}T000000"}}""") )
       .check(status is 200)
@@ -99,6 +105,8 @@ object EventSteps {
   def updateEvent(): HttpRequestBuilder = {
     http("updateEvent")
       .put(s"$SabreBaseUrl$${$EventLink}")
+      .header("Accept", "application/json, text/plain, */*")
+      .header("Content-Type", "application/calendar+json")
       .header(ESNToken, s"$${$Token}")
       .body(StringBody(s"$${$NewEventContent}"))
       .check(status is 204)

--- a/src/main/scala/com/linagora/openpaas/gatling/core/authentication/basiclogin/BasicLoginTemplateRequestsList.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/authentication/basiclogin/BasicLoginTemplateRequestsList.scala
@@ -32,7 +32,6 @@ object BasicLoginTemplateRequestsList {
     "/js/constants.js",
     "/components/angular-translate/angular-translate.min.js",
     "/generated/js/welcome/js/core",
-    "/moment-timezone/builds/moment-timezone-with-data.min.js",
     "/generated/css/welcome/styles.css",
     "/images/logo-tiny.png",
     "/images/white-logo.svg",


### PR DESCRIPTION
Now we send direct requests to Sabre and not via ESN's DAV Proxy, we need to configure the headers properly to tell Sabre to accept JSON & send back JSON.