### PR TITLE
do a distinction between username and login in feeder csv

### DIFF
--- a/src/main/scala/com/linagora/openpaas/gatling/core/authentication/basiclogin/BasicLoginSteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/authentication/basiclogin/BasicLoginSteps.scala
@@ -25,7 +25,7 @@ object BasicLoginSteps {
   def login: HttpRequestBuilder =
     http("Login")
       .post("/api/login")
-      .body(StringBody(s"""{"username":"$${$UsernameSessionParam}","password":"$${$PasswordSessionParam}","rememberme":false,"recaptcha":{"needed":false,"data":null}}"""))
+      .body(StringBody(s"""{"username":"$${$UsernameForLoginSessionParam}","password":"$${$PasswordSessionParam}","rememberme":false,"recaptcha":{"needed":false,"data":null}}"""))
       .check(status.is(200))
       .check(jsonPath("$._id").saveAs(UserId))
 

--- a/src/main/scala/com/linagora/openpaas/gatling/core/authentication/lemonldap/LemonLdapSteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/authentication/lemonldap/LemonLdapSteps.scala
@@ -43,7 +43,7 @@ object LemonLdapSteps {
       .formParam("url", "")
       .formParam("timezone", "1")
       .formParam("skin", "bootstrap")
-      .formParam("user", s"$${$UsernameSessionParam}")
+      .formParam("user", s"$${$UsernameForLoginSessionParam}")
       .formParam("password", s"$${$PasswordSessionParam}")
       .check(status is 200)
 

--- a/src/main/scala/com/linagora/openpaas/gatling/core/authentication/oidc/OIDCSteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/authentication/oidc/OIDCSteps.scala
@@ -49,7 +49,7 @@ object OIDCSteps {
       .formParam("url", "")
       .formParam("timezone", "1")
       .formParam("skin", "bootstrap")
-      .formParam("user", s"$${$UsernameSessionParam}")
+      .formParam("user", s"$${$UsernameForLoginSessionParam}")
       .formParam("password", s"$${$PasswordSessionParam}")
       .check(status.is(302),
         header("Location")

--- a/src/main/scala/com/linagora/openpaas/gatling/core/authentication/pkce/PKCESteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/authentication/pkce/PKCESteps.scala
@@ -48,7 +48,7 @@ object PKCESteps {
       .formParam("url", Base64.getEncoder.encodeToString((LemonLDAPPortalUrl + "//oauth2").getBytes(Charsets.UTF_8)))
       .formParam("timezone", "1")
       .formParam("skin", "bootstrap")
-      .formParam("user", s"$${$UsernameSessionParam}")
+      .formParam("user", s"$${$UsernameForLoginSessionParam}")
       .formParam("password", s"$${$PasswordSessionParam}")
       .disableFollowRedirect
       .check(status.is(302),

--- a/src/main/scala/com/linagora/openpaas/gatling/core/authentication/pkceWithCas/PKCEWithCasSteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/authentication/pkceWithCas/PKCEWithCasSteps.scala
@@ -112,7 +112,7 @@ object PKCEWithCasSteps {
       .formParam("execution", "${cas_execution}")
       .formParam("geolocation", "")
       .formParam("_eventId", "submit")
-      .formParam("username", s"$${$UsernameSessionParam}")
+      .formParam("username", s"$${$UsernameForLoginSessionParam}")
       .formParam("password", s"$${$PasswordSessionParam}")
       .disableFollowRedirect
       .check(status.is(302),

--- a/src/main/scala/com/linagora/openpaas/gatling/provisionning/SessionKeys.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/provisionning/SessionKeys.scala
@@ -1,6 +1,7 @@
 package com.linagora.openpaas.gatling.provisionning
 
 object SessionKeys {
+  val UsernameForLoginSessionParam = "login"
   val UsernameSessionParam = "username"
   val PasswordSessionParam = "password"
   val OtherUsername = "otherUsername"

--- a/src/test/resources/users.csv.sample
+++ b/src/test/resources/users.csv.sample
@@ -1,1 +1,1 @@
-username,password
+username,login,password


### PR DESCRIPTION
allow to use username without domain for use in login portal. And still have the username with domain to be used when sending mails