### PR TITLE
Stop user scenario if login fails

### DIFF
--- a/src/main/scala/com/linagora/openpaas/gatling/core/LoginSteps.scala
+++ b/src/main/scala/com/linagora/openpaas/gatling/core/LoginSteps.scala
@@ -75,7 +75,7 @@ object LoginSteps {
         .exec(PKCEWithCasSteps.loadLoginCasTemplates)
         .exec(PKCEWithCasSteps.login)
         .exec(PKCEWithCasSteps.casProfile)
-        .exec(PKCEWithCasSteps.casProxySSO)
+        .exec(PKCEWithCasSteps.casProxySSO).exitHereIfFailed
         .exec(PKCEWithCasSteps.obtainAuthorizationCode)
         .exec(PKCEToken.getToken)
         .exec(PKCEWithCasSteps.goToOpenPaaSApplication)


### PR DESCRIPTION
It's useless to let the user scenario run in that case, as any other
useful request will also fail, user user being not authenticated.

Tested live on the charge system.